### PR TITLE
Refactor of "User" model + Hooked up with authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,22 @@
   "dependencies": {
     "assert": "^1.3.0",
     "battlenet-api": "^0.9.1",
+    "bluebird": "^2.9.30",
     "body-parser": "^1.13.1",
     "cookie-parser": "^1.3.5",
     "cookie-session": "^1.1.0",
+    "cryptr": "^1.0.0",
     "debug": "^2.2.0",
     "express": "^4.13.0",
     "express-session": "^1.11.3",
+    "extend": "^2.0.1",
     "passport": "^0.2.2",
     "passport-bnet": "^1.1.1",
     "path": "^0.11.14",
     "rethinkdb": "^2.0.2",
-    "swig": "^1.4.2"
+    "rethinkdbdash": "^2.0.15",
+    "sprintf-js": "^1.0.2",
+    "swig": "^1.4.2",
+    "thinky": "^2.0.7"
   }
 }

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -11,18 +11,15 @@ Object.keys(env).forEach(function(key){
 });
 process.env.ROOT = path.normalize(__dirname + '/..');
 
-var db = require(__dirname + '/bootstrap/config/db/rethinkdb.js');
-
 exports.startup = function(app, passport){
-  console.log("Bootstrap: Setting up database (RethinkDB)");
-  db.setup();
+  var dbConfig = require(process.env.ROOT + '/server/bootstrap/config/db/rethinkdb.js');
 
   console.log("Bootstrap: Setting up autoload models");
   var modelsPath = '/server/mvc/models';
   Models = {};
   fs.readdirSync(process.env.ROOT + modelsPath).forEach(function(file){
     if (~file.indexOf('.js')) {
-      require(process.env.ROOT + modelsPath + '/' + file)(db.getInstance());
+      require(process.env.ROOT + modelsPath + '/' + file)(dbConfig.config());
     }
   });
 

--- a/server/bootstrap/config/db/rethinkdb.js
+++ b/server/bootstrap/config/db/rethinkdb.js
@@ -1,64 +1,9 @@
-var r = require('rethinkdb'),
-  assert = require('assert'),
-  logdebug = require('debug')('rdb:debug');
-
-
-// #### Connection details
-
-// RethinkDB database settings. Defaults can be overridden using environment variables.
 var dbConfig = {
   host: process.env.DB_HOST,
   port: parseInt(process.env.DB_PORT),
-  db  : process.env.DB_NAME,
-  tables: {
-    'messages': 'id',
-    'cache': 'cid',
-    'users': 'id'
-  }
+  db: process.env.DB_NAME
 };
 
-module.exports.setup = function(){
-  r.connect({host: dbConfig.host, port: dbConfig.port }, function (err, connection) {
-    assert.ok(err === null, err);
-    r.dbCreate(dbConfig.db).run(connection, function(err, result) {
-      if(err) {
-        logdebug("[DEBUG] RethinkDB database '%s' already exists (%s:%s)\n%s", dbConfig.db, err.name, err.msg, err.message);
-      }
-      else {
-        logdebug("[INFO] RethinkDB database '%s' created", dbConfig.db);
-      }
-
-      for(var tbl in dbConfig.tables) {
-        (function (tableName) {
-          r.db(dbConfig.db).tableCreate(tableName, {primaryKey: dbConfig.tables[tbl]}).run(connection, function(err, result) {
-            if(err) {
-              logdebug("[DEBUG] RethinkDB table '%s' already exists (%s:%s)\n%s", tableName, err.name, err.msg, err.message);
-            }
-            else {
-              logdebug("[INFO] RethinkDB table '%s' created", tableName);
-            }
-          });
-        })(tbl);
-      }
-    });
-  });
+module.exports.config = function(){
+  return dbConfig;
 };
-
-exports.getInstance = function(){
-  return r;
-};
-
-// #### Helper functions
-
-/**
- * A wrapper function for the RethinkDB API `r.connect`
- * to keep the configuration details in a single function
- * and fail fast in case of a connection error.
- */
-onConnect = function(callback) {
-  r.connect({host: dbConfig.host, port: dbConfig.port }, function(err, connection) {
-    assert.ok(err === null, err);
-    connection['_id'] = Math.floor(Math.random()*10001);
-    callback(err, connection);
-  });
-}

--- a/server/bootstrap/passport/bnet.js
+++ b/server/bootstrap/passport/bnet.js
@@ -1,5 +1,3 @@
-var session = require('express-session');
-
 var BnetStrategy = require('passport-bnet').Strategy;
 
 module.exports = new BnetStrategy(
@@ -9,7 +7,37 @@ module.exports = new BnetStrategy(
     scope: "sc2.profile",
     callbackURL: "https://localhost/auth/bnet/callback"
   }, function(accessToken, refreshToken, profile, done) {
-    session.OAuthAccessToken = accessToken;
-    return done(null, profile);
+    if (accessToken !== null && profile.id > 0) {
+      var user = new Models.User;
+      user
+        .findByUserId(profile.id)
+        .then(function(){
+          user.setValues({
+              oauthTokenEncrypted: user.encryptOauthToken(accessToken),
+              oauthType: "bnet"
+          }).updateTimeLatestLogin();
+          if (!user.exists()) {
+            user.setValues({
+                userId: profile.id
+            });
+          }
+          user
+            .save()
+            .then(function(){
+              console.log('Save: success', user.getValues());
+              return done(null, profile);
+            })
+            .error(function(err){
+              console.log("BnetStrategy (2):", err);
+              return done(null, null);
+            });
+        })
+        .error(function(err){
+          console.log("BnetStrategy (1):", err);
+          return done(null, null);
+        });
+    } else {
+      return done(null, null);
+    }
   }
 );

--- a/server/mvc/controllers/index.js
+++ b/server/mvc/controllers/index.js
@@ -13,14 +13,13 @@ exports.index = function(req, res){
 };
 
 exports.userstuff = function(req, res){ // TODO: Temporary function for hacking away at user stuff
-  if(req.isAuthenticated()) {
-    var user = new Models.User;
-    user.findByUserId(req.user.id, function(err, userData){
-      console.log('user.getObjectName()', user.getObjectName(), userData);
-      res.send('See output in terminal');
+  var user = new Models.User;
+  user.findByUserId(req.user.id)
+    .then(function(){
+      console.log("user.getValues()", user.getValues());
+    })
+    .error(function(err){
+      console.log("user.findByUserId error", err);
     });
-  } else {
-    res.redirect('/');
-    return;
-  }
+  res.send('just user stuff');
 };

--- a/server/mvc/controllers/profile.js
+++ b/server/mvc/controllers/profile.js
@@ -6,9 +6,11 @@ exports.info = function(req, res){
     res.redirect('/');
     return;
   }
+  /*
+  TODO: Implement using "Models.User"
   bnet.account.sc2({origin: 'eu', access_token: session.OAuthAccessToken}, function(bnetErr, bnetResp){
     res.send(JSON.stringify(bnetResp));
-  });
+  });*/
 };
 
 exports.matchhistory = function(req, res){

--- a/server/mvc/models/User.js
+++ b/server/mvc/models/User.js
@@ -1,41 +1,118 @@
-var _rethinkdb,
-    _name = module.filename.slice(module.filename.lastIndexOf('/')+1, module.filename.length).replace(/\.(.*?)$/, '');
+var Promise = require("bluebird");
+var Cryptr = require("cryptr");
+
+var thinky, r;
+var ThinkyUserModel;
 
 Models.User = function(){
-  var rethinkdb = _rethinkdb;
-  var name = _name;
-  var dbContents = null;
+  var self = this,
+    document = new ThinkyUserModel({}),
+    cryptr = null,
+    exists = false;
 
-  this.findByUserId = function(userId, callback){
-    dbContents = null;
-    console.log("User.findByUserId("+userId+")");
-    onConnect(function(err, connection){
-      rethinkdb
-        .db(process.env.DB_NAME)
-        .table('users')
-        .filter({"userId":userId})
+  this.findByUserId = function(userId){
+    exists = false;
+    return new Promise(function(resolve, reject){
+      ThinkyUserModel
+        .filter({"userId": userId})
+        .orderBy(r.desc("timeCreated"))
         .limit(1)
-        .run(connection)
-        .then(function(result){
-          dbContents = result;
+        .run()
+        .then(function(docs){
+          if (Array.isArray(docs) && docs.length) {
+            exists = true;
+            document = docs[0];
+          }
+          return resolve();
         })
-        .error(function(err){
-          logerror("[ERROR][%s][findUserById] %s:%s\n%s", connection['_id'], err.name, err.msg, err.message);
-        })
-        .finally(function(){
-          connection.close();
-          callback(null, dbContents);
-        });
+        .error(reject);
     });
   };
-  this.getObjectName = function(){
-    return name;
+  this.save = function(){
+    exists = false;
+    return new Promise(function(resolve, reject){
+      document.merge({"timeModified": r.now()});
+      try {
+        document.validate();
+      } catch (e) {
+        return reject(e);
+      }
+      document
+        .save()
+        .then(function(){
+          exists = true;
+          return resolve();
+        })
+        .error(reject);
+    });
+  };
+  this.setValue = function(key, value){
+    var obj = {};
+    obj[key] = value;
+    document.merge(obj);
+    document.validate();
+    return this;
+  };
+  this.setValues = function(obj){
+    document.merge(obj);
+    document.validate();
+    return this;
+  };
+  this.getValue = function(key){
+    var values = self.getValues();
+    if (values.hasOwnProperty(key)) {
+      return values[key];
+    }
+    return null;
+  };
+  this.getValues = function(){
+    var clone = {};
+    for (var i in document) {
+      if (document.hasOwnProperty(i))
+        clone[i] = document[i];
+    }
+    return clone;
   };
   this.isValid = function(){
-    return (typeof(dbContents) == 'object' && dbContents !== null);
+    try {
+      document.validate();
+    } catch (e) {
+      return false;
+    }
+    return true;
+  };
+  this.exists = function(){
+    return exists;
+  };
+  this.updateTimeLatestLogin = function(){
+    document.timeLatestLogin = r.now();
+    return this;
+  };
+  this.encryptOauthToken = function(token){
+    return self.getCryptr().encrypt(token);
+  };
+  this.decryptOauthToken = function(encryptedToken){
+    return self.getCryptr().decrypt(encryptedToken);
+  };
+  this.getCryptr = function(){
+    if (cryptr === null) {
+      cryptr = new Cryptr(process.env.BNET_OAUTH_TOKEN_ENCRYPTION_SALT);
+    }
+    return cryptr;
   };
 };
 
-module.exports = function(rethinkdb) {
-  _rethinkdb = rethinkdb;
+module.exports = function(dbConfig) {
+  thinky = require("thinky")(dbConfig);
+  r = thinky.r;
+  var type = thinky.type;
+  ThinkyUserModel = thinky.createModel("users", {
+    userId: type.number().integer().default(null).min(1).required().allowNull(false),
+    oauthType: type.string().default(null).min(1).required().allowNull(false),
+    oauthTokenEncrypted: type.string().default(null).min(1).required().allowNull(false),
+    timeCreated: type.date().default(r.now()).required().allowNull(false),
+    timeModified: type.date().default(r.now()).required().allowNull(false),
+    timeLatestLogin: type.date().default(r.now()).required().allowNull(false),
+  });
+  ThinkyUserModel.ensureIndex("timeCreated");
 };


### PR DESCRIPTION
I completely refactored the "User" model (`Models.User`). It now uses [thinky](https://www.npmjs.com/package/thinky) and [rethinkdbdash](https://www.npmjs.com/package/rethinkdbdash) (because the syntax in standard [rethinkdb](https://www.npmjs.com/package/rethinkdb) is simply horrific).

Also, when a user logs in (via Bnet) the respective user is either created (first login) or if the user already exists, credentials are updated. The oauth token is encrypted and stored in the database for later use.