### PR TITLE
Include userId with user creation

### DIFF
--- a/server/bootstrap/passport/strategies/bnet.js
+++ b/server/bootstrap/passport/strategies/bnet.js
@@ -11,14 +11,10 @@ module.exports = new BnetStrategy(
         .findByUserId(profile.id)
         .then(function(){
           user.setValues({
+              userId: profile.id,
               oauthTokenEncrypted: user.encryptOauthToken(accessToken, config.auth.bnet.encryptionSalt),
               oauthType: "bnet"
           }).updateTimeLatestLogin();
-          if (!user.exists()) {
-            user.setValues({
-                userId: profile.id
-            });
-          }
           user
             .save()
             .then(function(){


### PR DESCRIPTION
I found that the issue I have been running into with the login is due to User.js -> setValues -> validate() (line 59).  One of you should confirm, but the reason why it has not been working for me is because it tries to validate against the "users" model schema described at the bottom of User.js:

````
userId: type.number().integer().default(null).min(1).required().allowNull(false),
````

The first setValues includes oauthTokenEncrypted and oauthType but not the required userId.  I see no point in keeping the !user.exists() block, so I included userId with the rest of the values to be set.  The tests pass because all of the fields are sent.

I think the only reason why we would want to check if the profile.id is already associated with a user is if that changes on Blizzard's end, which it really should not.  I did consider allowing null for userId, but that would defeat the purpose of validate.  

I know that @kafoso has not run into this issue, but if anyone has any suggestions on how we should address this otherwise, let me know.