### PR TITLE
User model refactor

### DIFF
--- a/server/mvc/controllers/IndexController.js
+++ b/server/mvc/controllers/IndexController.js
@@ -21,9 +21,10 @@ exports.userstuff = function(req, res){ // TODO: Temporary function for hacking 
   user.findByUserId(req.user.id)
     .then(function(){
       console.log("user.getValues()", user.getValues());
+      return res.send('just user stuff');
     })
     .error(function(err){
       console.log("user.findByUserId error", err);
+      return res.send("user.findByUserId error");
     });
-  res.send('just user stuff');
 };

--- a/server/mvc/controllers/ProfileController.js
+++ b/server/mvc/controllers/ProfileController.js
@@ -9,7 +9,7 @@ exports.info = function(req, res){
   user
     .findByUserId(req.user.id)
     .then(function(){
-      if (!user.exists()) {
+      if (!user.existsInDatabase()) {
         throw new Error('User does not exit');
       }
       var oauthToken = user.decryptOauthToken(user.getValue('oauthTokenEncrypted'));

--- a/server/mvc/models/User.js
+++ b/server/mvc/models/User.js
@@ -8,29 +8,21 @@ var config,
 
 module.exports = function(){
   var self = this,
-    document = new ThinkyModel({}),
-    exists = false;
+    document = new ThinkyModel({});
 
   this.findByUserId = function(userId){
-    exists = false;
     return new Promise(function(resolve, reject){
       ThinkyModel
-        .filter({"userId": userId})
-        .orderBy(r.desc("timeCreated"))
-        .limit(1)
+        .get(userId)
         .run()
-        .then(function(docs){
-          if (Array.isArray(docs) && docs.length) {
-            exists = true;
-            document = docs[0];
-          }
+        .then(function(doc){
+          document = doc;
           return resolve();
         })
         .error(reject);
     });
   };
   this.save = function(){
-    exists = false;
     return new Promise(function(resolve, reject){
       document.merge({"timeModified": r.now()});
       try {
@@ -41,7 +33,6 @@ module.exports = function(){
       document
         .save()
         .then(function(){
-          exists = true;
           return resolve();
         })
         .error(reject);
@@ -82,8 +73,8 @@ module.exports = function(){
     }
     return true;
   };
-  this.exists = function(){
-    return exists;
+  this.existsInDatabase = function(){
+    return document.isSaved();
   };
   this.updateTimeLatestLogin = function(){
     document.timeLatestLogin = r.now();
@@ -111,6 +102,8 @@ module.exports.init = function(_config, _thinky){
     timeCreated: type.date().default(r.now()).required().allowNull(false),
     timeModified: type.date().default(r.now()).required().allowNull(false),
     timeLatestLogin: type.date().default(r.now()).required().allowNull(false),
+  }, {
+    "pk": "userId"
   });
   ThinkyModel.ensureIndex("timeCreated");
 };

--- a/tests/unit/server/mvc/models/UserTest.js
+++ b/tests/unit/server/mvc/models/UserTest.js
@@ -1,6 +1,12 @@
 var path = require("path");
 
-var bogusConfig = {},
+var bogusConfig = {
+    auth: {
+      bnet: {
+        encryptionSalt: "encryption_salt_123"
+      }
+    }
+  },
   bogusThinkyConfig = {db: "bogus"},
   Models = {};
 
@@ -15,30 +21,17 @@ module.exports = {
     var bogusThinky = require("thinky")(bogusThinkyConfig);
     bogusThinky.r.table("users").delete().run().finally(callback);
   },
-  "Can findByUserId": function(test) {
-    test.expect(1);
+  "Can findByUserId, but promise rejects (error)": function(test) {
+    test.expect(3);
     var user = new Models.User();
     user
       .findByUserId(1)
-      .then(function(){
-        test.equal(typeof(user.getValues()), "object", "Has bogus valus");
-        test.done();
-      })
       .error(function(err){
-        test.done();
-      });
-  },
-  "Found user is not valid and does not exist in database": function(test) {
-    test.expect(2);
-    var user = new Models.User();
-    user
-      .findByUserId(1)
-      .then(function(){
         test.ok(!user.isValid(), "Should not be valid");
-        test.ok(!user.exists(), "Should not exist");
-        test.done();
+        test.ok(!user.existsInDatabase(), "Should not exist in database");
+        test.equal(typeof(user.getValues()), "object", "Has bogus valus");
       })
-      .error(function(err){
+      .finally(function(){
         test.done();
       });
   },
@@ -47,12 +40,11 @@ module.exports = {
     var user = new Models.User();
     user
       .save()
-      .then(function(){
-        test.done();
-      })
       .error(function(err){
         test.ok(!user.isValid(), "Should not be valid");
-        test.ok(!user.exists(), "Should not exist");
+        test.ok(!user.existsInDatabase(), "Should not exist");
+      })
+      .finally(function(){
         test.done();
       });
   },
@@ -68,7 +60,7 @@ module.exports = {
       .save()
       .then(function(){
         test.ok(user.isValid(), "Should be valid");
-        test.ok(user.exists(), "Should exist");
+        test.ok(user.existsInDatabase(), "Should exist");
         test.strictEqual(user.getValue('userId'), 1, "Value: userId");
         test.strictEqual(user.getValue('oauthType'), "bogus", "Value: oauthType");
         test.strictEqual(user.getValue('oauthTokenEncrypted'), "123bogus", "Value: oauthType");
@@ -81,7 +73,7 @@ module.exports = {
   "Oauth token is encrypted correctly": function(test){
     test.expect(1);
     var user = new Models.User();
-    var encryptedToken = user.encryptOauthToken("my_little_oauth_token", "encryption_salt_123");
+    var encryptedToken = user.encryptOauthToken("my_little_oauth_token");
     test.strictEqual(encryptedToken, "41a65d5a9d2156f20daff6add137ea3465854d5c3c262ddb52ae64251d7a9d9e");
     test.done();
   },
@@ -89,7 +81,7 @@ module.exports = {
     test.expect(1);
     var user = new Models.User();
     var encryptedToken = "41a65d5a9d2156f20daff6add137ea3465854d5c3c262ddb52ae64251d7a9d9e";
-    var token = user.decryptOauthToken(encryptedToken, "encryption_salt_123");
+    var token = user.decryptOauthToken(encryptedToken);
     test.strictEqual(token, "my_little_oauth_token");
     test.done();
   },


### PR DESCRIPTION
@theevenprime2 

This is a response to: https://github.com/Starbow/website/pull/12

I refactored the `User` model to better utilize promises and to improve readability, e.g. in https://github.com/Starbow/website/blob/0242fb0b582b54db1d845cfdb6ff7ee2a90e47b8/server/bootstrap/passport/strategies/bnet.js#L11

Important changes:

- `userId` is now the primary key in the `users` table. Please drop the table in rethinkdb.
- If `findByUserId` fails (promise is rejected), this method rejects, too.