### PR TITLE
Introduced "cluster"; server application is now multi-threaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ node_modules
 
 # Sensitive data
 server/data/*
-server/bootstrap/config/env/env.json
+server/config/env/env.json

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following stacks/software is needed in order to run the server on your local
 2. Clone repository: `git clone https://github.com/Starbow/website`
 3. Run `npm install` to get all dependencies which are stored in the folder `node_modules`
 4. Clone/download the live Rethink database and import it into your local environment. (**Note:** We should probably consider doing an automated script for this purpose)
-5. Setup the `env.json` file (`/server/bootstrap/config/env/env.json`). **Note:** NEVER add this to git.
+5. Setup the `env.json` file (`/server/config/env/env.json`). **Note:** NEVER add this to git.
 
 ## Configuring SSH-key for git
 
@@ -98,8 +98,8 @@ The folders are structured as follows:
   * [`/cdn`](#folder-public-cdn)
 * [`/server`](#folder-server)
   * [`/boostrap`](#folder-server-bootstrap)
-    * [`/config`](#folder-server-bootstrap-config)
-      * [`/env`](#folder-server-bootstrap-config-env)
+  * [`/config`](#folder-server-config)
+    * [`/env`](#folder-server-config-env)
   * [`/data`](#folder-server-data)
   * [`/mvc`](#folder-server-mvc)
     * [`/controllers`](#folder-server-mvc-controllers)
@@ -148,11 +148,12 @@ A publicly accessible folder within which assets (images, css, etc.) are stored.
 * <a name="folder-server"></a>`/server`<br/>
 Server logic, exclusively.
   * <a name="folder-server-bootstrap"></a>`/bootstrap`
-  The server's bootstrap/startup code. Configures logs, `express`, `passport`, routing, etc.
-    * <a name="folder-server-bootstrap-config"></a>`/config`<br/>
-    Contains server configurations such as log settings, database connection information, authentication data, etc.
-      * <a name="folder-server-bootstrap-config-env"></a>`/env`<br/>
-      Environment specific configurations ("production", "development", or "test").
+  The server's bootstrap/startup code. Runs for each worker spawned by the `cluster` module. Configures `express`, `passport`, routing, etc.
+  * <a name="folder-server-config"></a>`/config`<br/>
+  Contains server configurations such as log settings, database connection information, authentication data, etc.<br/>
+  These configurations apply to Master as well as all Worker processes spawned by `cluster`.
+    * <a name="folder-server-config-env"></a>`/env`<br/>
+    Environment specific configurations ("production", "development", or "test").
   * <a name="folder-server-data"></a>`/data`<br/>
   Data folder containing logs, cached data, and temporarily stored files. The folder is excluded from Git, but will automatically be generated on system startup (in the bootstrap).
   * <a name="folder-server-mvc"></a>`/mvc`<br/>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "battlenet-api": "^0.9.3",
     "bluebird": "^2.9.30",
     "body-parser": "^1.13.1",
+    "cluster": "^0.7.7",
     "cookie-parser": "^1.3.5",
     "cookie-session": "^1.1.0",
     "cryptr": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -1,24 +1,71 @@
 var fs = require('fs');
 var express = require('express');
-var bootstrap = require(__dirname + '/server/bootstrap.js');
+var cluster = require('cluster');
+var sprintf = require('sprintf-js').sprintf;
 
-var app = express();
-bootstrap.startup(app);
+if (cluster.isMaster) {
+  console.log("SERVER STARTED");
+}
 
-// Create an HTTPS service
-var https = require('https');
-var server = https.createServer({
-  key: fs.readFileSync(__dirname + process.env.SSL_KEY),
-  cert: fs.readFileSync(__dirname + process.env.SSL_CERTIFICATE)
-}, app).listen(process.env.PORT, process.env.HOST);
+if (cluster.isMaster) {
+  console.log(" - Initializing");
+}
+var config = require("./server/config/config")();
 
-// Fallback: HTTP service which redirects to HTTPS
-var http = require('http');
-http.createServer(function(req, res){
-  res.writeHead(301, { "Location": "https://" + req.headers['host'] + req.url });
-  res.end();
-}).listen(80, process.env.HOST);
+if (cluster.isMaster) {
+  console.log(" - Ensuring 'server/data' directory exists");
+}
+var dataDirPath = process.env.ROOT + "/server/data";
+if (!fs.existsSync(dataDirPath)) {
+  fs.mkdirSync(dataDirPath);
+}
 
-bootstrap.onReady(function(){
-  console.log('Secure server running at https://'+process.env.HOST+'/ (port: '+process.env.PORT+')');
-});
+if (cluster.isMaster) {
+  console.log(" - Configuring logs");
+}
+var logs = require('./server/config/logs');
+logs.init(config);
+
+if (cluster.isMaster) {
+  var cpuCount = require('os').cpus().length;
+  logs.cluster.info(sprintf('Server: %s workers available. Start them up...', cpuCount));
+   // Firstly, disable console.log spam and keep cluster from automatically grabbing stdin/out/err
+  //cluster.setupMaster({silent: true});
+  // Fork workers
+  for (var i=0; i<cpuCount; i++) {
+      cluster.fork();
+  }
+  cluster.on('online', function(worker){
+    logs.cluster.info(sprintf('Server: Worker online: [id: %s] [pid: %s]', worker.id, worker.process.pid));
+  });
+  cluster.on('exit', function(deadWorker, code, signal){
+    logs.cluster.warn(sprintf('Server: Worker died: [id: %s] [pid: %s] [code: %s] [signal: %s]',
+      worker.id, deadWorker.process.pid, code, signal));
+    var worker = cluster.fork(); // Restart the worker
+    logs.cluster.warn(sprintf('Server: Worker [id: %s] [pid: %s] replaced with new worker: [id: %s] [pid: %s]',
+      worker.id, deadWorker.process.pid, worker.id, worker.process.pid));
+  });
+} else {
+  var bootstrap = require(__dirname + '/server/bootstrap.js');
+  var app = express();
+  bootstrap.startup(app, config, logs);
+
+  // Create an HTTPS service
+  var https = require('https');
+  var server = https.createServer({
+    key: fs.readFileSync(__dirname + process.env.SSL_KEY),
+    cert: fs.readFileSync(__dirname + process.env.SSL_CERTIFICATE)
+  }, app).listen(process.env.PORT, process.env.HOST);
+
+  // Fallback: HTTP service which redirects to HTTPS
+  var http = require('http');
+  http.createServer(function(req, res){
+    res.writeHead(301, { "Location": "https://" + req.headers['host'] + req.url });
+    res.end();
+  }).listen(80, process.env.HOST);
+
+  bootstrap.onReady(function(){
+    logs.cluster.info(sprintf("Worker [id: %s][pid: %s]: Secure server running at https://%s/ (port: %s)",
+      cluster.worker.id, cluster.worker.process.pid, process.env.HOST, process.env.PORT));
+  });
+}

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -1,4 +1,3 @@
-var logs = require("./logs");
 var morgan = require("morgan");
 var sprintf = require("sprintf-js").sprintf;
 var IndexController = require(process.env.ROOT + '/server/mvc/controllers/IndexController.js');
@@ -24,6 +23,7 @@ module.exports = function (app, logs, passport) {
   if (process.env.NODE_ENV == 'development') {
     var DevExamplesController = require(process.env.ROOT + '/server/mvc/controllers/DevExamplesController.js');
     app.get('/dev-examples', DevExamplesController["index"]);
+    app.get('/dev-examples/cluster-current-worker', DevExamplesController["cluster-current-worker"]);
     app.get('/dev-examples/model-interaction', DevExamplesController["model-interaction"]);
     app.get('/dev-examples/provoke-framework-error', DevExamplesController["provoke-framework-error"]);
     app.get('/dev-examples/retrieve-config-from-model', DevExamplesController["retrieve-config-from-model"]);

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,6 +1,8 @@
 var fs = require("fs");
 var sprintf = require("sprintf-js").sprintf;
 
+require("./env/env.js");
+
 var config = {
   auth: {
     bnet: {
@@ -25,15 +27,32 @@ var config = {
         stream: process.env.LOG_ACCESS_FILE
       }
     },
-    framework: { // winston
+    cluster: {
       console: {
-        level: 'error',
+        level: 'debug',
         handleExceptions: true,
         json: false,
         colorize: true
       },
       file: {
-        level: 'error',
+        level: 'debug',
+        filename: process.env.LOG_CLUSTER_FILE,
+        handleExceptions: true,
+        json: false,
+        maxsize: 5242880, //5MB
+        maxFiles: 5,
+        colorize: false
+      }
+    },
+    framework: { // winston
+      console: {
+        level: 'debug',
+        handleExceptions: true,
+        json: false,
+        colorize: true
+      },
+      file: {
+        level: 'debug',
         filename: process.env.LOG_FRAMEWORK_FILE,
         handleExceptions: true,
         json: false,

--- a/server/config/env/env.js
+++ b/server/config/env/env.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var path = require("path");
 var sprintf = require("sprintf-js").sprintf;
 
-var rootDir = path.normalize(__dirname + "/../../../..");
+var rootDir = path.normalize(__dirname + "/../../..");
 var env;
 var envFile = __dirname + '/env.json';
 

--- a/server/config/logs.js
+++ b/server/config/logs.js
@@ -26,6 +26,7 @@ var getWinstonLog = function(subConfig){
 
 module.exports.init = function(config){
   module.exports.access = getMorganLog(config.log.access);
+  module.exports.cluster = getWinstonLog(config.log.cluster);
   module.exports.framework = getWinstonLog(config.log.framework);
   module.exports.mvc = getWinstonLog(config.log.mvc);
   delete module.exports.init; // Voodoo: The function deletes itself to prevent re-init

--- a/server/mvc/controllers/DevExamplesController.js
+++ b/server/mvc/controllers/DevExamplesController.js
@@ -1,6 +1,15 @@
 var log = require("../log");
 var Models = require('../models.js');
 var assert = require('assert');
+var cluster = require('cluster');
+var sprintf = require('sprintf-js').sprintf;
+
+/**
+ * Example: How to get informations about the current "worker" from cluster.
+ */
+exports["cluster-current-worker"] = function(req, res){
+  return res.send(sprintf("The current worker is: [id: %s]", cluster.worker.id));
+};
 
 /**
  * Example: How interact with a model.


### PR DESCRIPTION
Introduced 'cluster'. The server application now utilizes all available CPUs; i.e. it's now multi-threaded.

- Greatly refactored `server.js` and `bootstrap.js`
  - `server.js`:
    - Now sets up system-wide configurations (previous, this was done in `bootstrap.js`)
    - Now spawns workers using the 'cluster' module; one per available core.
    - When a worker dies, it is automatically logged (in `/server/data/logs/cluster.log`) and the worker script is re-started by the "Master" script.
  - `bootstrap.js`:
    - Sets up and handles logic "per worker".
- Moved 'config' folder; it's now in `/server/config` - outside `/server/bootstrap/`- since bootstrap now handles logic 'per worked' and 'config' is system-wide.