### PR TITLE
Refactor: 'env.*.json' files are environment specific + Added 'env.example.json' + Additional validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 # Sensitive data
 server/data/*
 server/config/env/env.*.json
+!server/config/env/env.example.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ node_modules
 
 # Sensitive data
 server/data/*
-server/config/env/env.json
+server/config/env/env.*.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ node_modules
 
 # Sensitive data
 server/data/*
-server/bootstrap/config/env/env.json
+server/config/env/env.json

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following stacks/software is needed in order to run the server on your local
 2. Clone repository: `git clone https://github.com/Starbow/website`
 3. Run `npm install` to get all dependencies which are stored in the folder `node_modules`
 4. Clone/download the live Rethink database and import it into your local environment. (**Note:** We should probably consider doing an automated script for this purpose)
-5. Setup the `env.json` file (`/server/bootstrap/config/env/env.json`). **Note:** NEVER add this to git.
+5. Setup the `env.json` file (`/server/config/env/env.json`). **Note:** NEVER add this to git.
 
 ## Configuring SSH-key for git
 
@@ -98,8 +98,8 @@ The folders are structured as follows:
   * [`/cdn`](#folder-public-cdn)
 * [`/server`](#folder-server)
   * [`/boostrap`](#folder-server-bootstrap)
-    * [`/config`](#folder-server-bootstrap-config)
-      * [`/env`](#folder-server-bootstrap-config-env)
+  * [`/config`](#folder-server-config)
+    * [`/env`](#folder-server-config-env)
   * [`/data`](#folder-server-data)
   * [`/mvc`](#folder-server-mvc)
     * [`/controllers`](#folder-server-mvc-controllers)
@@ -148,11 +148,12 @@ A publicly accessible folder within which assets (images, css, etc.) are stored.
 * <a name="folder-server"></a>`/server`<br/>
 Server logic, exclusively.
   * <a name="folder-server-bootstrap"></a>`/bootstrap`
-  The server's bootstrap/startup code. Configures logs, `express`, `passport`, routing, etc.
-    * <a name="folder-server-bootstrap-config"></a>`/config`<br/>
-    Contains server configurations such as log settings, database connection information, authentication data, etc.
-      * <a name="folder-server-bootstrap-config-env"></a>`/env`<br/>
-      Environment specific configurations ("production", "development", or "test").
+  The server's bootstrap/startup code. Runs for each worker spawned by the `cluster` module. Configures `express`, `passport`, routing, etc.
+  * <a name="folder-server-config"></a>`/config`<br/>
+  Contains server configurations such as log settings, database connection information, authentication data, etc.<br/>
+  These configurations apply to Master as well as all Worker processes spawned by `cluster`.
+    * <a name="folder-server-config-env"></a>`/env`<br/>
+    Environment specific configurations ("production", "development", or "test").
   * <a name="folder-server-data"></a>`/data`<br/>
   Data folder containing logs, cached data, and temporarily stored files. The folder is excluded from Git, but will automatically be generated on system startup (in the bootstrap).
   * <a name="folder-server-mvc"></a>`/mvc`<br/>

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ The following stacks/software is needed in order to run the server on your local
 1. Create/go to the directory on your machine from which you want to run the website code.
 2. Clone repository: `git clone https://github.com/Starbow/website`
 3. Run `npm install` to get all dependencies which are stored in the folder `node_modules`
-4. Clone/download the live Rethink database and import it into your local environment. (**Note:** We should probably consider doing an automated script for this purpose)
-5. Setup the `env.json` file (`/server/config/env/env.json`). **Note:** NEVER add this to git.
+4. Clone/download the live Rethink database and import it into your local environment.
+  - **Note:** We should probably consider doing an automated script for this purpose
+5. Setup the `env.development.json` file (in `/server/config/env/env.json`).
+  - You can base the JSON on the contents in `env.example.json`, and change the values accordingly.
+  - **Note:** NEVER add these files to git: [`env.production.json`, `env.development.json`, `env.test.json`]
+  - The structure of `env.example.json` must match that of the environment specific `env.*.json` files.
 
 ## Configuring SSH-key for git
 
@@ -36,7 +40,9 @@ If you don't feel like writing your Git password every time you want to push to 
 ## Running the application
 
 1. Start the database. In a separate tab/window in your terminal write: `rethinkdb`
-2. Start the server. In the root folder (`/website`), run `sudo node server.js` to start the application. (**Note:** Using port numbers below 3000, which 443 is, requires `sudo` privileges)
+2. Start the server. In the root folder (`/website`), run `sudo node server.js` to start the application.
+  - **Note:** Using port numbers below 3000, which 443 is, requires `sudo` privileges.
+  - If you haven't configured the environment variable `NODE_ENV`, you may need to run: `sudo NODE_ENV=development node server.js`.
 3. In your terminal, you'll now see output as the server is being configured or potentially throws errors.
 4. In your browser, go to: [https://localhost](https://localhost)
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "rethinkdbdash": "^2.0.15",
     "sprintf-js": "^1.0.2",
     "thinky": "^2.0.7",
+    "underscore": "^1.8.3",
     "use-strict": "^1.0.1",
     "winston": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "battlenet-api": "^0.9.3",
     "bluebird": "^2.9.30",
     "body-parser": "^1.13.1",
+    "cluster": "^0.7.7",
     "cookie-parser": "^1.3.5",
     "cookie-session": "^1.1.0",
     "cryptr": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -1,24 +1,71 @@
 var fs = require('fs');
 var express = require('express');
-var bootstrap = require(__dirname + '/server/bootstrap.js');
+var cluster = require('cluster');
+var sprintf = require('sprintf-js').sprintf;
 
-var app = express();
-bootstrap.startup(app);
+if (cluster.isMaster) {
+  console.log("SERVER STARTED");
+}
 
-// Create an HTTPS service
-var https = require('https');
-var server = https.createServer({
-  key: fs.readFileSync(__dirname + process.env.SSL_KEY),
-  cert: fs.readFileSync(__dirname + process.env.SSL_CERTIFICATE)
-}, app).listen(process.env.PORT, process.env.HOST);
+if (cluster.isMaster) {
+  console.log(" - Initializing");
+}
+var config = require("./server/config/config")();
 
-// Fallback: HTTP service which redirects to HTTPS
-var http = require('http');
-http.createServer(function(req, res){
-  res.writeHead(301, { "Location": "https://" + req.headers['host'] + req.url });
-  res.end();
-}).listen(80, process.env.HOST);
+if (cluster.isMaster) {
+  console.log(" - Ensuring 'server/data' directory exists");
+}
+var dataDirPath = process.env.ROOT + "/server/data";
+if (!fs.existsSync(dataDirPath)) {
+  fs.mkdirSync(dataDirPath);
+}
 
-bootstrap.onReady(function(){
-  console.log('Secure server running at https://'+process.env.HOST+'/ (port: '+process.env.PORT+')');
-});
+if (cluster.isMaster) {
+  console.log(" - Configuring logs");
+}
+var logs = require('./server/config/logs');
+logs.init(config);
+
+if (cluster.isMaster) {
+  var cpuCount = require('os').cpus().length;
+  logs.cluster.info(sprintf('Server: %s workers available. Start them up...', cpuCount));
+   // Firstly, disable console.log spam and keep cluster from automatically grabbing stdin/out/err
+  //cluster.setupMaster({silent: true});
+  // Fork workers
+  for (var i=0; i<cpuCount; i++) {
+      cluster.fork();
+  }
+  cluster.on('online', function(worker){
+    logs.cluster.info(sprintf('Server: Worker online: [id: %s] [pid: %s]', worker.id, worker.process.pid));
+  });
+  cluster.on('exit', function(deadWorker, code, signal){
+    logs.cluster.warn(sprintf('Server: Worker died: [id: %s] [pid: %s] [code: %s] [signal: %s]',
+      worker.id, deadWorker.process.pid, code, signal));
+    var worker = cluster.fork(); // Restart the worker
+    logs.cluster.warn(sprintf('Server: Worker [id: %s] [pid: %s] replaced with new worker: [id: %s] [pid: %s]',
+      worker.id, deadWorker.process.pid, worker.id, worker.process.pid));
+  });
+} else {
+  var bootstrap = require(__dirname + '/server/bootstrap.js');
+  var app = express();
+  bootstrap.startup(app, config, logs);
+
+  // Create an HTTPS service
+  var https = require('https');
+  var server = https.createServer({
+    key: fs.readFileSync(__dirname + process.env.SSL_KEY),
+    cert: fs.readFileSync(__dirname + process.env.SSL_CERTIFICATE)
+  }, app).listen(process.env.PORT, process.env.HOST);
+
+  // Fallback: HTTP service which redirects to HTTPS
+  var http = require('http');
+  http.createServer(function(req, res){
+    res.writeHead(301, { "Location": "https://" + req.headers['host'] + req.url });
+    res.end();
+  }).listen(80, process.env.HOST);
+
+  bootstrap.onReady(function(){
+    logs.cluster.info(sprintf("Worker [id: %s][pid: %s]: Secure server running at https://%s/ (port: %s)",
+      cluster.worker.id, cluster.worker.process.pid, process.env.HOST, process.env.PORT));
+  });
+}

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -1,4 +1,3 @@
-var logs = require("./logs");
 var morgan = require("morgan");
 var sprintf = require("sprintf-js").sprintf;
 var IndexController = require(process.env.ROOT + '/server/mvc/controllers/IndexController.js');
@@ -24,6 +23,7 @@ module.exports = function (app, logs, passport) {
   if (process.env.NODE_ENV == 'development') {
     var DevExamplesController = require(process.env.ROOT + '/server/mvc/controllers/DevExamplesController.js');
     app.get('/dev-examples', DevExamplesController["index"]);
+    app.get('/dev-examples/cluster-current-worker', DevExamplesController["cluster-current-worker"]);
     app.get('/dev-examples/model-interaction', DevExamplesController["model-interaction"]);
     app.get('/dev-examples/provoke-framework-error', DevExamplesController["provoke-framework-error"]);
     app.get('/dev-examples/retrieve-config-from-model', DevExamplesController["retrieve-config-from-model"]);

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,6 +1,8 @@
 var fs = require("fs");
 var sprintf = require("sprintf-js").sprintf;
 
+require("./env/env.js");
+
 var config = {
   auth: {
     bnet: {
@@ -25,15 +27,32 @@ var config = {
         stream: process.env.LOG_ACCESS_FILE
       }
     },
-    framework: { // winston
+    cluster: {
       console: {
-        level: 'error',
+        level: 'debug',
         handleExceptions: true,
         json: false,
         colorize: true
       },
       file: {
-        level: 'error',
+        level: 'debug',
+        filename: process.env.LOG_CLUSTER_FILE,
+        handleExceptions: true,
+        json: false,
+        maxsize: 5242880, //5MB
+        maxFiles: 5,
+        colorize: false
+      }
+    },
+    framework: { // winston
+      console: {
+        level: 'debug',
+        handleExceptions: true,
+        json: false,
+        colorize: true
+      },
+      file: {
+        level: 'debug',
         filename: process.env.LOG_FRAMEWORK_FILE,
         handleExceptions: true,
         json: false,

--- a/server/config/env/env.example.json
+++ b/server/config/env/env.example.json
@@ -1,0 +1,18 @@
+{
+  "BNET_ID": "",
+  "BNET_SECRET": "",
+  "BNET_OAUTH_TOKEN_ENCRYPTION_SALT": "",
+  "DB_HOST": "localhost",
+  "DB_PORT": 28015,
+  "DB_NAME": "",
+  "LOG_ACCESS_FILE": "a.log",
+  "LOG_CLUSTER_FILE": "b.log",
+  "LOG_FRAMEWORK_FILE": "c.log",
+  "LOG_MVC_FILE": "d.log",
+  "HOST": "localhost",
+  "NODE_ENV": "development",
+  "PORT": 443,
+  "PROTOCOL": "https",
+  "SSL_KEY": "/path/to/localhost.key",
+  "SSL_CERTIFICATE": "/path/to/localhost.crt"
+}

--- a/server/config/env/env.example.json
+++ b/server/config/env/env.example.json
@@ -10,7 +10,6 @@
   "LOG_FRAMEWORK_FILE": "c.log",
   "LOG_MVC_FILE": "d.log",
   "HOST": "localhost",
-  "NODE_ENV": "development",
   "PORT": 443,
   "PROTOCOL": "https",
   "SSL_KEY": "/path/to/localhost.key",

--- a/server/config/env/env.js
+++ b/server/config/env/env.js
@@ -2,19 +2,30 @@ var fs = require("fs");
 var path = require("path");
 var sprintf = require("sprintf-js").sprintf;
 
+var ACCEPTED_NODE_ENVS = ["production", "development", "test"];
+if (process.env.NODE_ENV === undefined || ACCEPTED_NODE_ENVS.indexOf(process.env.NODE_ENV) <= -1) {
+  throw new Error("Invalid NODE_ENV; process.env.NODE_ENV=" + process.env.NODE_ENV + "\n"
+    + "Please:\n"
+    + "  (1) Add 'export NODE_ENV=<ENVIRONMENT_NAME>' to your '.profile', or\n"
+    + "  (2) Run 'NODE_ENV=<ENVIRONMENT_NAME> node server.js'\n"
+    + "Replace '<ENVIRONMENT_NAME>' with one of: [\"" + ACCEPTED_NODE_ENVS.join('", "') + "\"]\n");
+}
+
 var rootDir = path.normalize(__dirname + "/../../..");
 var env;
-var envFile = __dirname + '/env.json';
+var envFileName = "env." + process.env.NODE_ENV + ".json";
+var envFilePath = __dirname + "/" + envFileName;
 
 try {
-  env = fs.readFileSync(envFile, 'utf-8');
+  env = fs.readFileSync(envFilePath, 'utf-8');
 } catch (e) {
-  throw new Error(sprintf("You don't have an 'env.json' file in '%s'", __dirname));
+  throw new Error(sprintf("You don't have an '%s' file in '%s'", envFileName, __dirname));
 }
 try {
   env = JSON.parse(env);
 } catch (e) {
-  throw new Error("Your 'env.json' file contains invalid JSON. Did you leave a comma before the final '}'?");
+  throw new Error(sprintf("Your '%s' file contains invalid JSON. Did you leave a comma before the final '}'?",
+    envFileName));
 }
 
 Object.keys(env).forEach(function(key){

--- a/server/config/env/env.js
+++ b/server/config/env/env.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var path = require("path");
 var sprintf = require("sprintf-js").sprintf;
 
-var rootDir = path.normalize(__dirname + "/../../../..");
+var rootDir = path.normalize(__dirname + "/../../..");
 var env;
 var envFile = __dirname + '/env.json';
 

--- a/server/config/env/env.js
+++ b/server/config/env/env.js
@@ -1,31 +1,60 @@
 var fs = require("fs");
 var path = require("path");
 var sprintf = require("sprintf-js").sprintf;
+var _ = require("underscore");
 
 var ACCEPTED_NODE_ENVS = ["production", "development", "test"];
 if (process.env.NODE_ENV === undefined || ACCEPTED_NODE_ENVS.indexOf(process.env.NODE_ENV) <= -1) {
   throw new Error("Invalid NODE_ENV; process.env.NODE_ENV=" + process.env.NODE_ENV + "\n"
     + "Please:\n"
-    + "  (1) Add 'export NODE_ENV=<ENVIRONMENT_NAME>' to your '.profile', or\n"
-    + "  (2) Run 'NODE_ENV=<ENVIRONMENT_NAME> node server.js'\n"
+    + "  (1) Add 'export NODE_ENV=<ENVIRONMENT_NAME>' to your '~/.profile' (and then 'source ~/.profile'), or\n"
+    + "  (2) Run 'NODE_ENV=<ENVIRONMENT_NAME> node server.js' instead\n"
     + "Replace '<ENVIRONMENT_NAME>' with one of: [\"" + ACCEPTED_NODE_ENVS.join('", "') + "\"]\n");
 }
 
 var rootDir = path.normalize(__dirname + "/../../..");
-var env;
-var envFileName = "env." + process.env.NODE_ENV + ".json";
-var envFilePath = __dirname + "/" + envFileName;
+var envFileName = "env." + process.env.NODE_ENV + ".json",
+  envFilePath = __dirname + "/" + envFileName,
+  envExampleFileName = "env.example.json",
+  envExampleFilePath = __dirname + "/" + envExampleFileName;
 
-try {
-  env = fs.readFileSync(envFilePath, 'utf-8');
-} catch (e) {
-  throw new Error(sprintf("You don't have an '%s' file in '%s'", envFileName, __dirname));
+var getAndValidateEnvFileJSON = function(name, path){
+  var json;
+  try {
+    json = fs.readFileSync(path, 'utf-8');
+  } catch (e) {
+    throw new Error(sprintf("You don't have an '%s' file in '%s'", name, __dirname));
+  }
+  try {
+    json = JSON.parse(json);
+  } catch (e) {
+    throw new Error(sprintf("Your '%s' file contains invalid JSON. Did you leave a comma before the final '}'?", name));
+  }
+  return json;
+};
+
+var env = getAndValidateEnvFileJSON(envFileName, envFilePath);
+var envExample = getAndValidateEnvFileJSON(envExampleFileName, envExampleFilePath);
+
+// Check for key differences
+var difference = _.difference(Object.keys(env), Object.keys(envExample));
+if (difference.length > 0) {
+  throw new Error(sprintf("The keys in '%s' and '%s' don't match. They must. Diverging keys are: ['%s']",
+    envFileName, envExampleFileName, difference.join("', '")));
 }
-try {
-  env = JSON.parse(env);
-} catch (e) {
-  throw new Error(sprintf("Your '%s' file contains invalid JSON. Did you leave a comma before the final '}'?",
-    envFileName));
+
+// Check for datatype differences
+var errors = [];
+for (var key in envExample) {
+  if (typeof(envExample[key]) != typeof(env[key])) {
+    errors.push(sprintf("Key '%s' must be of type '%s'; found '%s'",
+      key, typeof(envExample[key]), typeof(env[key])));
+  }
+}
+if (errors.length) {
+  console.log('errors', errors)
+  throw new Error(sprintf("found datatype mismatch(es) between '%s' and '%s':\n - %s\n",
+    envFileName, envExampleFileName, errors.join("\n -")));
 }
 
 Object.keys(env).forEach(function(key){

--- a/server/config/logs.js
+++ b/server/config/logs.js
@@ -26,6 +26,7 @@ var getWinstonLog = function(subConfig){
 
 module.exports.init = function(config){
   module.exports.access = getMorganLog(config.log.access);
+  module.exports.cluster = getWinstonLog(config.log.cluster);
   module.exports.framework = getWinstonLog(config.log.framework);
   module.exports.mvc = getWinstonLog(config.log.mvc);
   delete module.exports.init; // Voodoo: The function deletes itself to prevent re-init

--- a/server/mvc/controllers/DevExamplesController.js
+++ b/server/mvc/controllers/DevExamplesController.js
@@ -1,6 +1,15 @@
 var log = require("../log");
 var Models = require('../models.js');
 var assert = require('assert');
+var cluster = require('cluster');
+var sprintf = require('sprintf-js').sprintf;
+
+/**
+ * Example: How to get informations about the current "worker" from cluster.
+ */
+exports["cluster-current-worker"] = function(req, res){
+  return res.send(sprintf("The current worker is: [id: %s]", cluster.worker.id));
+};
 
 /**
  * Example: How interact with a model.


### PR DESCRIPTION
- `env.json` is gone. Instead, an `env.*.json` file must exist per environment; environments being: ["production", "development", "test"]
- (Re)added `env.example.json`
- The structure of the `env.example.json` file dictates the structure and value data types in the `env.*.json` file. This forces us to remember to update `env.example.json`.

I've updated [README.md](https://github.com/Starbow/website/blob/d947db082464049ff2cb7824b776f240d711b286/README.md) to reflect the changes. See step 5 here: https://github.com/Starbow/website/blob/d947db082464049ff2cb7824b776f240d711b286/README.md#installation